### PR TITLE
chore: update config for CVM v0.10.4

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,19 +1,29 @@
-cvm-version: 0.7.3
+cvm-version: 0.10.4
 cpus: 16
-gpus: 1
 memory: 65536
+gpus: 1
+
+models:
+  - name: "nomic-embed-text-v1.5"
+    repo: "nomic-ai/nomic-embed-text-v1.5@e5cf08aadaa33385f5990def41f7a23405aec398"
+    mpk: "868790ff0e4820086091a6a63097f194a0a17bc431dd616538eb7881ecdbd935_2215256064_328142c7-83ed-5f89-a463-0a11367cf58f"
 
 containers:
   - name: "nomic-embed-text-v1.5"
     image: "ghcr.io/huggingface/text-embeddings-inference@sha256:346a39baecdd03c40e77184c66a4a9931ec2e25b8e57ff3766b79affdbd38673"
     runtime: nvidia
     gpus: all
-    command: [
-      "--model-id", "nomic-ai/nomic-embed-text-v1.5",
-      "--revision", "e5cf08aadaa33385f5990def41f7a23405aec398",
-      "--served-model-name", "nomic-embed-text",
-      "--port", "8001",
-    ]
+    restart: always
+    command: ["--model-id", "/tinfoil/mpk/mpk-868790ff0e4820086091a6a63097f194a0a17bc431dd616538eb7881ecdbd935", "--served-model-name",
+      "nomic-embed-text", "--port", "8001"]
+    tmpfs:
+      /tmp: size=512m,mode=1777,exec
+      /root: size=2g,mode=0700,exec
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 60m
 
 shim:
   upstream-port: 8001


### PR DESCRIPTION
## Summary
- Bump CVM version to 0.10.4
- Use MPK-based model path
- Add tmpfs, healthcheck, and restart policy

## Test plan
- [x] Validated e2e-nomic deployment on inf10